### PR TITLE
Improving Homepage Content

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -7,14 +7,17 @@ import Button from './Button.vue'
     <div class="items-center justify-center mx-auto max-w-[1250px]">
       <div class="flex md:flex-col flex-col-reverse lg:flex-row justify-center relative">
         <div class="">
-          <h1 class="font-lufga text-4xl mt-8 sm:text-5xl lg:text-6xl font-semibold lg:w-[50%] md:mt-0">
-            Run <span class="text-[#7587F5]">iOS</span> games and apps <span
-              class="text-[#66D6D7]"
-            >natively</span> on your Mac.
-          </h1>
           <h1 class="pt-4 text-gray-700 dark:text-gray-300 font-lufga text-lg sm:text-xl">
-            Apple took this feature away, so we brought it back!
+            PlayCover expands Mac's App Store library!
           </h1>
+          <p class="font-lufga text-4xl mt-8 sm:text-5xl lg:text-6xl font-semibold lg:w-[50%] md:mt-0">
+            Run <span class="text-[#7587F5]">iOS</span> & <span class="text-[#7587F5]">iPadOS</span> apps and games <span
+              class="text-[#66D6D7]"
+            >natively</span> on your Apple Silicon Mac.
+          </p>
+          <p class="pt-4 text-gray-700 dark:text-gray-300 font-lufga text-lg sm:text-xl">
+            Apple took this feature away, so we brought it back.
+          </p>
         </div>
         <slot />
       </div>


### PR DESCRIPTION
Chnages:
- Adding a true H1 content
- Changing other contents to a P tag instead of H1
- Some content changes

Reasons:
- Multiple H1s in home pages are somehow bad for SEO
- The word "PlayCover" (our master keyword) was not in any of texts also needs to be in a H1 tag
- iPadOS is gaining more exclusive apps and games, so we should have mention it
- "Mac" refers to all kind of Macs while PlayCover only works on Apple Silicon ones, so it needs to be pinpointed.