### PR TITLE
fix contributor and release lists

### DIFF
--- a/src/components/ContributorsList.vue
+++ b/src/components/ContributorsList.vue
@@ -3,7 +3,7 @@ import type { Ref } from 'vue'
 import { ref } from 'vue'
 import { filterContributorsData } from '../utils/utils'
 const contributorsArray: Ref<any> = ref(null)
-contributorsArray.value = await fetch('orgContributors.json').then(response =>
+contributorsArray.value = await fetch('https://raw.githubusercontent.com/PlayCover/PlaySite/master/orgContributors.json').then(response =>
   response.json(),
 ).then(data => data)
 contributorsArray.value = filterContributorsData(contributorsArray.value).filter(contributor => contributor.username != null || contributor.username !== 'weblate')

--- a/src/components/Release.vue
+++ b/src/components/Release.vue
@@ -31,10 +31,11 @@ const markdownHTML = marked.parse(markdown)
       >
         <div>
           <div class="flex items-center my-4">
-            <!-- <img
+            <img
+              v-if="props.release.author"
               :src="props.release.author.avatar_url" :alt="props.release.author.login"
               :title="props.release.author.login" class="border-2 rounded-full mt-1 h-8 w-8"
-            > -->
+            >
             <span
               class="ml-2.5 mt-1 text-2xl font-itcavantgardestdmd bg-clip-text text-transparent bg-gradient-to-r from-pc-g to-pc-b"
             >{{

--- a/src/components/Release.vue
+++ b/src/components/Release.vue
@@ -31,10 +31,10 @@ const markdownHTML = marked.parse(markdown)
       >
         <div>
           <div class="flex items-center my-4">
-            <img
+            <!-- <img
               :src="props.release.author.avatar_url" :alt="props.release.author.login"
               :title="props.release.author.login" class="border-2 rounded-full mt-1 h-8 w-8"
-            >
+            > -->
             <span
               class="ml-2.5 mt-1 text-2xl font-itcavantgardestdmd bg-clip-text text-transparent bg-gradient-to-r from-pc-g to-pc-b"
             >{{

--- a/src/components/ReleasesList.vue
+++ b/src/components/ReleasesList.vue
@@ -3,7 +3,7 @@ import { type Ref, ref } from 'vue'
 import Release from './Release.vue'
 
 const releasesArray: Ref<any> = ref(null)
-releasesArray.value = await fetch('releases.json').then(response =>
+releasesArray.value = await fetch('https://raw.githubusercontent.com/PlayCover/PlaySite/master/releases.json').then(response =>
   response.json(),
 ).then(data => data)
 </script>


### PR DESCRIPTION
The contributor and changelog pages do not load correctly, due to a possible change in behavior with `fetch()`. This method now fetches the latest json from the repo instead of whatever the old method was.